### PR TITLE
Fixed SELF_TEST_ENABLED being defined

### DIFF
--- a/Firmware/BlynkBoard_Core_Firmware/BlynkBoard_Core_Firmware.ino
+++ b/Firmware/BlynkBoard_Core_Firmware/BlynkBoard_Core_Firmware.ino
@@ -26,7 +26,7 @@ ESP8266 Arduino Core - version 2.1.0-rc2 <- Critical, must be up-to-date
 ******************************************************************************/
 
 //#define DEBUG_ENABLED
-#define SELF_TEST_ENABLED
+//#define SELF_TEST_ENABLED
 //#define CAPTIVE_PORTAL_ENABLE
 
 #include "BlynkBoard_settings.h"


### PR DESCRIPTION
By having SELF_TEST_ENABLED on line 29, the code enters the conditional statement on line 107, which will have it run a modified self-test function. According to line 112, and confirmed by multiple tests, the performSelfTest() function will end in an infinite loop on both success or fail, which binds the code and does not let it continue to the MODE_WAIT_CONFIG runMode.